### PR TITLE
Support for node attributes + Added Right Click Extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,8 @@
 # knowledgeforum.org
 
-knowledgeforum.org is a single sign on site created for the knowledge forum system.  
+[knowledgeforum.org](https://knowledgeforum.org/) is a single sign on site created for the knowledge forum system.  
 
 # Links
-
-[knowledgeforum.org](https://knowledgeforum.org/)
 
 [Knowledge Forum System Repository](https://github.com/SERG-UAlbany/KF6-UAlbany/wiki)
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ knowledgeforum.org is a single sign on site created for the knowledge forum syst
 
 # Links
 
+[knowledgeforum.org](https://knowledgeforum.org/)
+
 [Knowledge Forum System Repository](https://github.com/SERG-UAlbany/KF6-UAlbany/wiki)
 
 [Software Requirements Specification Document](https://drive.google.com/file/d/1aXMRLE6gBj9XuWALB4YZFdnbwiy5Tozg/view?usp=sharing)

--- a/package-lock.json
+++ b/package-lock.json
@@ -4530,6 +4530,14 @@
         "jquery": "^1.4 || ^2.0 || ^3.0"
       }
     },
+    "cytoscape-spread": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/cytoscape-spread/-/cytoscape-spread-3.0.0.tgz",
+      "integrity": "sha512-ekuo4ByFRTZ4TOJylE2bPOMcVVyi8rD+qjvEjMWS2BHcyan40pmhlA4ramz/nTxZR+EtlxEa1asnmfiN8R5HyQ==",
+      "requires": {
+        "weaverjs": "^1.2.0"
+      }
+    },
     "cytoscape-supportimages": {
       "version": "git+https://github.com/SERG-UAlbany/cytoscape.js-supportimages.git#eb2f84e8da918e7bc2dd0f3d8288b82b6ee98a11",
       "from": "git+https://github.com/SERG-UAlbany/cytoscape.js-supportimages.git"
@@ -14067,6 +14075,11 @@
       "requires": {
         "minimalistic-assert": "^1.0.0"
       }
+    },
+    "weaverjs": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/weaverjs/-/weaverjs-1.2.0.tgz",
+      "integrity": "sha1-ZUwVzHNbZgodrkx8JjzXx0ZRL6A="
     },
     "webidl-conversions": {
       "version": "4.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -4512,6 +4512,11 @@
         "lodash.debounce": "^4.0.8"
       }
     },
+    "cytoscape-context-menus": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/cytoscape-context-menus/-/cytoscape-context-menus-4.0.0.tgz",
+      "integrity": "sha512-+WC0r7nExd1e3gwHe2Pk0tcDU8MU1HIfbHs6Z3cfamZY2M+tAvP20X5SoregMQ6IN3IQkg4KU59q1hJlvbwzcw=="
+    },
     "cytoscape-node-html-label": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/cytoscape-node-html-label/-/cytoscape-node-html-label-1.2.2.tgz",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "axios": "^0.21.1",
     "bootstrap": "^4.6.0",
     "cytoscape": "^3.18.2",
+    "cytoscape-context-menus": "^4.0.0",
     "cytoscape-node-html-label": "^1.2.2",
     "cytoscape-panzoom": "^2.5.3",
     "cytoscape-supportimages": "git+https://github.com/SERG-UAlbany/cytoscape.js-supportimages.git",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "cytoscape-context-menus": "^4.0.0",
     "cytoscape-node-html-label": "^1.2.2",
     "cytoscape-panzoom": "^2.5.3",
+    "cytoscape-spread": "^3.0.0",
     "cytoscape-supportimages": "git+https://github.com/SERG-UAlbany/cytoscape.js-supportimages.git",
     "jquery": "^3.6.0",
     "popper.js": "^1.16.1",

--- a/src/components/CommunityView/GraphView/GraphView.jsx
+++ b/src/components/CommunityView/GraphView/GraphView.jsx
@@ -503,7 +503,7 @@ class GraphView extends Component {
     this.loadElements();
 
     var ref = this;
-    // on single click of node log its kf id and mark it as read
+    // open contribution on tap of its node
     cy.on('tap', 'node', function(event){
       var kfId = this.data('kfId');
       var type = this.data('type');
@@ -520,51 +520,64 @@ class GraphView extends Component {
 
     });
 
-      cy.on('boxselect', 'node', (evt) => {
-        var cy_node = evt.target;
-        cy_node.addClass('selected')
-      });
+    // when a node is selected in a box select add styling to reflect that
+    cy.on('boxselect', 'node', (evt) => {
+      var cy_node = evt.target;
+      cy_node.addClass('selected')
+    });
 
-      cy.on('unselect', 'node', (evt) => {
-        var cy_node = evt.target;
-        cy_node.removeClass('selected')
-      });
+    // remove styling from boxselect on unselect
+    cy.on('unselect', 'node', (evt) => {
+      var cy_node = evt.target;
+      cy_node.removeClass('selected')
+    });
 
-      cy.on('dragfree', 'node', (evt) => {
-          const {x, y} = evt.target.position();
+    // update view link position if node is moved
+    cy.on('dragfree', 'node', (evt) => {
+        const {x, y} = evt.target.position();
 
-          var kfId = evt.target.data().kfId;
+        var kfId = evt.target.data().kfId;
 
-          let viewLink = Object.values(this.props.viewLinks).filter((link) => link.to === kfId)
-          if (viewLink !== undefined && viewLink.length) {
-              viewLink = viewLink[0];
-              const data = {x, y}
-              const newViewLink = { ...viewLink }
-              newViewLink.data = { ...newViewLink.data, ...data };
-              this.props.updateViewLink(newViewLink)
-          }
-      })
+        let viewLink = Object.values(this.props.viewLinks).filter((link) => link.to === kfId)
+        if (viewLink !== undefined && viewLink.length) {
+            viewLink = viewLink[0];
+            const data = {x, y}
+            const newViewLink = { ...viewLink }
+            newViewLink.data = { ...newViewLink.data, ...data };
+            this.props.updateViewLink(newViewLink)
+        }
+    })
 
-      //Update view link of image if position is changed
-      cy.on('cysupportimages.imagemoved', (evt, img) => {
-          let viewLink = this.props.viewLinks[img.linkId]
-          if (viewLink !== undefined) {
-              const data = {x: img.bounds.x, y: img.bounds.y}
-              const newViewLink = { ...viewLink }
-              newViewLink.data = { ...newViewLink.data, ...data };
-              this.props.updateViewLink(newViewLink)
-          }
-      })
+    // open image contribution when it is selected
+    cy.on('cysupportimages.imageselected', (evt, img) => {
+      // wait 100ms to see if it is just being moved
+      // if it is we do not open the contribution
+      window.setTimeout(function(){
+        if(!img._private.dragging){ ref.props.onNoteClick(img.kfId); }
+      }, 100);
+    })
 
-      cy.on('cysupportimages.imageresized', (evt, img, b1, b2) => {
-          let viewLink = this.props.viewLinks[img.linkId]
-          if (viewLink !== undefined) {
-              const data = {width: img.bounds.width, height: img.bounds.height}
-              const newViewLink = { ...viewLink }
-              newViewLink.data = { ...newViewLink.data, ...data };
-              this.props.updateViewLink(newViewLink)
-          }
-      })
+    //Update view link position of image if moved
+    cy.on('cysupportimages.imagemoved', (evt, img) => {
+        let viewLink = this.props.viewLinks[img.linkId]
+        if (viewLink !== undefined) {
+            const data = {x: img.bounds.x, y: img.bounds.y}
+            const newViewLink = { ...viewLink }
+            newViewLink.data = { ...newViewLink.data, ...data };
+            this.props.updateViewLink(newViewLink)
+        }
+    })
+
+    //Update view link of image if resized
+    cy.on('cysupportimages.imageresized', (evt, img, b1, b2) => {
+        let viewLink = this.props.viewLinks[img.linkId]
+        if (viewLink !== undefined) {
+            const data = {width: img.bounds.width, height: img.bounds.height}
+            const newViewLink = { ...viewLink }
+            newViewLink.data = { ...newViewLink.data, ...data };
+            this.props.updateViewLink(newViewLink)
+        }
+    })
   }
 
   componentDidUpdate(prevProps, prevState) {

--- a/src/components/CommunityView/GraphView/GraphView.jsx
+++ b/src/components/CommunityView/GraphView/GraphView.jsx
@@ -22,7 +22,7 @@ import unread_riseabove_icon from '../../../assets/icon_riseabove_blue.png';
 import read_riseabove_icon from '../../../assets/icon_riseabove_red.png';
 import attachment_icon from '../../../assets/icon_attachment.gif';
 import view_icon from '../../../assets/icon_view.png';
-import {MINZOOM, MAXZOOM} from '../../../config.js';
+import {MIN_ZOOMED_FONT_SIZE, MINZOOM, MAXZOOM} from '../../../config.js';
 
 Cytoscape.use(CytoscapePanZoom);
 Cytoscape.use(CytoscapeNodeHtmlLabel);
@@ -361,8 +361,10 @@ class GraphView extends Component {
 
   }
 
+  // helper function for handling running different types of layouts
   runLayout(layoutType){
     var cy = this.cy;
+    // for preset we just reset the state and rerender the entire graph
     if(layoutType === "preset"){
       this.setState({
         elements: {nodes: [], edges: []},
@@ -373,7 +375,14 @@ class GraphView extends Component {
       this.loadElements(Object.keys(this.props.viewLinks).length, true);
       cy.reset();
     } else {
-      var layout = (layoutType === "spread") ? ({name: layoutType, animate: false, prelayout: false}) : {name: layoutType};
+      // for spread layout we specify some parameters for running it
+      // otherwise we just run layouts as default
+      var layout = (layoutType === "spread") ? ({
+        name: layoutType,
+        animate: false,
+        prelayout: false,
+      })
+      : {name: layoutType};
       cy.layout(layout).run();
     }
   }
@@ -439,7 +448,7 @@ class GraphView extends Component {
         ],
     };
 
-    var ctxMenuInstance = cy.contextMenus(options);
+    cy.contextMenus(options);
 
     // CYTOSCAPE-NODE-HTML-LABEL EXTENSION
     cy.nodeHtmlLabel([
@@ -451,112 +460,87 @@ class GraphView extends Component {
         valignBox: 'bottom', // title relative box vertical position. Can be 'top',''center, 'bottom'
         cssClass: 'cytoscape-label', // any classes will be as attribute of <div> container for every title
         tpl: function(data){
-          // we only want author and creation date listed for notes
           if(data.type === 'note' || data.type === 'riseabove' || data.type === 'Attachment' || data.type === 'Drawing'){
             return '<div>' + (data.groupName !== null ? data.groupName : data.author) + '<br>' + data.date + '</div>';
           }
-          return '';
         }
       },
       {
         query: '.nodehtmllabel-group-author-nodate',
-        halign: 'center', // title horizontal position. Can be 'left',''center, 'right'
-        valign: 'bottom', // title vertical position. Can be 'top',''center, 'bottom'
-        halignBox: 'right', // title relative box horizontal position. Can be 'left',''center, 'right'
-        valignBox: 'bottom', // title relative box vertical position. Can be 'top',''center, 'bottom'
-        cssClass: 'cytoscape-label', // any classes will be as attribute of <div> container for every title
+        halign: 'center',
+        valign: 'bottom',
+        halignBox: 'right',
+        valignBox: 'bottom',
+        cssClass: 'cytoscape-label',
         tpl: function(data){
-          // we only want author and creation date listed for notes
           if(data.type === 'note' || data.type === 'riseabove' || data.type === 'Attachment' || data.type === 'Drawing'){
             return '<div>' + (data.groupName !== null ? data.groupName : data.author) + '</div>';
           }
-          return '';
         }
       },
       {
         query: '.nodehtmllabel-group-noauthor-date',
-        halign: 'center', // title horizontal position. Can be 'left',''center, 'right'
-        valign: 'bottom', // title vertical position. Can be 'top',''center, 'bottom'
-        halignBox: 'right', // title relative box horizontal position. Can be 'left',''center, 'right'
-        valignBox: 'bottom', // title relative box vertical position. Can be 'top',''center, 'bottom'
-        cssClass: 'cytoscape-label', // any classes will be as attribute of <div> container for every title
+        halign: 'center',
+        valign: 'bottom',
+        halignBox: 'right',
+        valignBox: 'bottom',
+        cssClass: 'cytoscape-label',
         tpl: function(data){
-          // we only want author and creation date listed for notes
           if(data.type === 'note' || data.type === 'riseabove' || data.type === 'Attachment' || data.type === 'Drawing'){
             return (data.groupName !== null) ? ('<div>' + data.groupName + '<br>' + data.date + '</div>') : ('<div>' + data.date + '</div>');
           }
-          return '';
         }
       },
       {
         query: '.nodehtmllabel-group-noauthor-nodate',
-        halign: 'center', // title horizontal position. Can be 'left',''center, 'right'
-        valign: 'bottom', // title vertical position. Can be 'top',''center, 'bottom'
-        halignBox: 'right', // title relative box horizontal position. Can be 'left',''center, 'right'
-        valignBox: 'bottom', // title relative box vertical position. Can be 'top',''center, 'bottom'
-        cssClass: 'cytoscape-label', // any classes will be as attribute of <div> container for every title
+        halign: 'center',
+        valign: 'bottom',
+        halignBox: 'right',
+        valignBox: 'bottom',
+        cssClass: 'cytoscape-label',
         tpl: function(data){
-          // we only want author and creation date listed for notes
           if(data.type === 'note' || data.type === 'riseabove' || data.type === 'Attachment' || data.type === 'Drawing'){
             return '<div>' + (data.groupName !== null ? data.groupName : '') + '</div>';
           }
-          return '';
         }
       },
       {
         query: '.nodehtmllabel-nogroup-author-date',
-        halign: 'center', // title horizontal position. Can be 'left',''center, 'right'
-        valign: 'bottom', // title vertical position. Can be 'top',''center, 'bottom'
-        halignBox: 'right', // title relative box horizontal position. Can be 'left',''center, 'right'
-        valignBox: 'bottom', // title relative box vertical position. Can be 'top',''center, 'bottom'
-        cssClass: 'cytoscape-label', // any classes will be as attribute of <div> container for every title
+        halign: 'center',
+        valign: 'bottom',
+        halignBox: 'right',
+        valignBox: 'bottom',
+        cssClass: 'cytoscape-label',
         tpl: function(data){
-          // we only want author and creation date listed for notes
           if(data.type === 'note' || data.type === 'riseabove' || data.type === 'Attachment' || data.type === 'Drawing'){
             return '<div>' + data.author + '<br>' + data.date + '</div>';
           }
-          return '';
         }
       },
       {
         query: '.nodehtmllabel-nogroup-author-nodate',
-        halign: 'center', // title horizontal position. Can be 'left',''center, 'right'
-        valign: 'bottom', // title vertical position. Can be 'top',''center, 'bottom'
-        halignBox: 'right', // title relative box horizontal position. Can be 'left',''center, 'right'
-        valignBox: 'bottom', // title relative box vertical position. Can be 'top',''center, 'bottom'
-        cssClass: 'cytoscape-label', // any classes will be as attribute of <div> container for every title
+        halign: 'center',
+        valign: 'bottom',
+        halignBox: 'right',
+        valignBox: 'bottom',
+        cssClass: 'cytoscape-label',
         tpl: function(data){
-          // we only want author and creation date listed for notes
           if(data.type === 'note' || data.type === 'riseabove' || data.type === 'Attachment' || data.type === 'Drawing'){
             return '<div>' + data.author + '</div>';
           }
-          return '';
         }
       },
       {
         query: '.nodehtmllabel-nogroup-noauthor-date',
-        halign: 'center', // title horizontal position. Can be 'left',''center, 'right'
-        valign: 'bottom', // title vertical position. Can be 'top',''center, 'bottom'
-        halignBox: 'right', // title relative box horizontal position. Can be 'left',''center, 'right'
-        valignBox: 'bottom', // title relative box vertical position. Can be 'top',''center, 'bottom'
-        cssClass: 'cytoscape-label', // any classes will be as attribute of <div> container for every title
+        halign: 'center',
+        valign: 'bottom',
+        halignBox: 'right',
+        valignBox: 'bottom',
+        cssClass: 'cytoscape-label',
         tpl: function(data){
-          // we only want author and creation date listed for notes
           if(data.type === 'note' || data.type === 'riseabove' || data.type === 'Attachment' || data.type === 'Drawing'){
             return '<div>' + data.date + '</div>';
           }
-          return '';
-        }
-      },
-      {
-        query: '.nodehtmllabel-nogroup-noauthor-nodate',
-        halign: 'center', // title horizontal position. Can be 'left',''center, 'right'
-        valign: 'bottom', // title vertical position. Can be 'top',''center, 'bottom'
-        halignBox: 'right', // title relative box horizontal position. Can be 'left',''center, 'right'
-        valignBox: 'bottom', // title relative box vertical position. Can be 'top',''center, 'bottom'
-        cssClass: 'cytoscape-label', // any classes will be as attribute of <div> container for every title
-        tpl: function(data){
-          return '';
         }
       },
     ]);
@@ -586,7 +570,8 @@ class GraphView extends Component {
         message: 'Use the "Original" layout on the sidebar button to restore the graph to its initial state.',
         dismiss: {duration: 5000}
       })
-      ref.props.updateParentLayoutProp({target: {value: "spread"}});
+      if(ref.props.layout !== "spread") ref.props.updateParentLayoutProp({target: {value: "spread"}});
+      else{ ref.runLayout("spread"); }
     });
 
     // remove styling from boxselect on unselect +
@@ -688,6 +673,7 @@ class GraphView extends Component {
               selector: 'node',
               style: {
                 'label': "data(name)",
+                'min-zoomed-font-size': MIN_ZOOMED_FONT_SIZE,
                 'font-size': '11px',
                 'text-halign': 'right',
                 'text-valign': 'center',
@@ -695,6 +681,7 @@ class GraphView extends Component {
                 'padding': '0',
                 'background-opacity': '0',
                 'background-clip': 'none',
+                'background-repeat': 'no-repeat',
                 'background-width': '15px',
                 'background-height': '15px',
                 'shape': 'round-rectangle',

--- a/src/components/CommunityView/GraphView/GraphView.jsx
+++ b/src/components/CommunityView/GraphView/GraphView.jsx
@@ -193,13 +193,14 @@ class GraphView extends Component {
     var self = this;
     switch (filter) {
         case "title":
-            // eslint-disable-next-line
             nodesToHide = cy.filter(function(elem, i){
                const elem_type = elem.data('type');
                const elem_title = elem.data('name');
                if((elem_type === "note" || elem_type === "View" || elem_type === "riseabove" || elem_type === "Attachment") && !elem_title.toLowerCase().includes(query.toLowerCase())){
                  return elem;
                }
+
+               return null;
             });
 
             // for(let i in imgs){
@@ -212,24 +213,24 @@ class GraphView extends Component {
             break;
 
         case "content":
-            // eslint-disable-next-line
             notes.filter(function (obj) {
                 if (obj.data && ( (obj.data.English && !obj.data.English.includes(query)) || (obj.data.body && !obj.data.body.includes(query)) ) ) {
                   var cy_ids = self.findCyIdsFromKfId(obj._id);
                   for(let j in cy_ids){ nodesToHide = nodesToHide.union(cy.$('#'+cy_ids[j])); }
                 }
+                return null;
             });
 
             break;
 
         case "author":
-            // eslint-disable-next-line
             nodesToHide = cy.filter(function(elem, i){
                const elem_type = elem.data('type');
                const elem_author = elem.data('author');
                if((elem_type === "note" || elem_type === "View" || elem_type === "riseabove" || elem_type === "Attachment") && !elem_author.toLowerCase().includes(query.toLowerCase())){
                  return elem;
                }
+               return null;
             });
 
             // for(let i in imgs){
@@ -243,29 +244,29 @@ class GraphView extends Component {
 
         case "scaffold":
             const noteIds = this.props.supports.filter(support => support.from === query).map(support => support.to);
-            // eslint-disable-next-line
             notes.filter(function(note){
               if(!noteIds.includes(note._id)){
                 var cy_ids = self.findCyIdsFromKfId(note._id);
                 for(let j in cy_ids){ nodesToHide = nodesToHide.union(cy.$('#'+cy_ids[j])); }
               }
+              return null;
             });
             break;
 
         case "time":
             var curr_date = new Date();
-            // eslint-disable-next-line
             nodesToHide = cy.filter(function(elem, i){
                const elem_date = new Date(elem.data('date'));
                if(elem.data('date') !== undefined && elem_date !== "Invalid Date"){
                  var diff = curr_date - elem_date;
                  var secondsDiff = diff/1000;
 
-                 if(query === "today" && !(secondsDiff <= 86400) ||
-                    query === "week" && !(secondsDiff <= 604800) ||
-                    query === "month" && !(secondsDiff <= 2592000) ||
-                    query === "year" && !(secondsDiff <= 31556952)){ return elem; }
+                 if((query === "today" && !(secondsDiff <= 86400)) ||
+                    (query === "week" && !(secondsDiff <= 604800)) ||
+                    (query === "month" && !(secondsDiff <= 2592000)) ||
+                    (query === "year" && !(secondsDiff <= 31556952))){ return elem; }
                }
+               return null;
             });
             break;
 

--- a/src/components/CommunityView/GraphView/GraphView_helper.js
+++ b/src/components/CommunityView/GraphView/GraphView_helper.js
@@ -62,6 +62,7 @@ function handleNote(server, token, id, nodeData, authorData, viewSettings, group
   var date = parseDate(nodeData.created);
   var readStatus, type;
   var groupName = nodeData._to.group ? groups.find(group => group._id === nodeData._to.group).title : null;
+  var isPositionLocked = nodeData.data.draggable !== undefined ? !nodeData.data.draggable : false;
 
   // handles whether it is a note or a riseabove
   if(nodeData._to.data === undefined){
@@ -82,8 +83,9 @@ function handleNote(server, token, id, nodeData, authorData, viewSettings, group
         date: date,
         kfId: nodeData.to,
         linkId: nodeData._id,
-        type: type
+        type: type,
       },
+      locked: isPositionLocked,
       classes: [readStatus, viewSettings.nodeClass],
       position: {
         x: nodeData.data.x,
@@ -95,11 +97,11 @@ function handleNote(server, token, id, nodeData, authorData, viewSettings, group
 
 // handles adding attachments to the cytoscape instance
 function handleAttachment(server, token, nodes, nodeData, authorData, viewSettings, groups){
-
   var authorName = matchAuthorId(nodeData._to.authors[0], authorData);
   var date = parseDate(nodeData.created);
   var groupName = nodeData._to.group ? groups.find(group => group._id === nodeData._to.group).title : null;
-  var showInPlace = nodeData.data.showInPlace ? nodeData.data.showInPlace : false;
+  var isPositionLocked = nodeData.data.draggable !== undefined ? !nodeData.data.draggable : false;
+  var showInPlace = nodeData.data.showInPlace !== undefined ? nodeData.data.showInPlace : false;
 
   return getApiObjectsObjectId(token, server, nodeData.to).then(function(result){
 
@@ -121,7 +123,7 @@ function handleAttachment(server, token, nodes, nodeData, authorData, viewSettin
         url: imageUrl,
         name: nodeData._to.title,
         bounds: bounds,
-        locked: false,
+        locked: isPositionLocked,
         linkId: nodeData._id,
         author: authorName,
         kfId: nodeData.to,
@@ -144,6 +146,7 @@ function handleAttachment(server, token, nodes, nodeData, authorData, viewSettin
           type: nodeData._to.type,
           download: server + result.data.url.substring(1,)
         },
+        locked: isPositionLocked,
         classes: ["attachment", viewSettings.nodeClass],
         position: {
           x: nodeData.data.x,
@@ -161,7 +164,8 @@ function handleDrawing(server, token, nodes, nodeData, authorData, viewSettings,
   var authorName = matchAuthorId(nodeData._to.authors[0], authorData);
   var date = parseDate(nodeData.created);
   var groupName = nodeData._to.group ? groups.find(group => group._id === nodeData._to.group).title : null;
-  var showInPlace = nodeData.data.showInPlace ? nodeData.data.showInPlace : false;
+  var isPositionLocked = nodeData.data.draggable !== undefined ? !nodeData.data.draggable : false;
+  var showInPlace = nodeData.data.showInPlace !== undefined ? nodeData.data.showInPlace : false;
 
   return getApiObjectsObjectId(token, server, nodeData.to).then(function(result){
     if(showInPlace){
@@ -188,7 +192,7 @@ function handleDrawing(server, token, nodes, nodeData, authorData, viewSettings,
         url: 'data:image/svg+xml;utf8,' + encodeURIComponent('<?xml version="1.0" encoding="UTF-8"?><!DOCTYPE svg>' + result.data.svg),
         name: nodeData._to.title,
         bounds: bounds,
-        locked: false,
+        locked: isPositionLocked,
         author: authorName,
         kfId: nodeData.to,
         type: nodeData._to.type,
@@ -211,6 +215,7 @@ function handleDrawing(server, token, nodes, nodeData, authorData, viewSettings,
           type: nodeData._to.type,
           download: 'data:image/svg+xml;utf8,' + encodeURIComponent('<?xml version="1.0" encoding="UTF-8"?><!DOCTYPE svg>' + result.data.svg)
         },
+        locked: isPositionLocked,
         classes: ["attachment", viewSettings.nodeClass],
         position: {
           x: nodeData.data.x,
@@ -227,6 +232,7 @@ function handleDrawing(server, token, nodes, nodeData, authorData, viewSettings,
 function handleView(nodes, nodeData, authorData){
   var id = createCytoscapeId(nodes, nodeData.to);
   var authorName = matchAuthorId(nodeData._to.authors[0], authorData);
+  var isPositionLocked = nodeData.data.draggable !== undefined ? !nodeData.data.draggable : false;
 
   return {
     group: 'nodes',
@@ -239,6 +245,7 @@ function handleView(nodes, nodeData, authorData){
       type: nodeData._to.type,
       communityId: nodeData.communityId,
     },
+    locked: isPositionLocked,
     classes: "view",
     position: {
       x: nodeData.data.x,

--- a/src/components/CommunityView/GraphView/GraphView_helper.js
+++ b/src/components/CommunityView/GraphView/GraphView_helper.js
@@ -63,6 +63,7 @@ function handleNote(server, token, id, nodeData, authorData, viewSettings, group
   var readStatus, type;
   var groupName = nodeData._to.group ? groups.find(group => group._id === nodeData._to.group).title : null;
   var isPositionLocked = nodeData.data.draggable !== undefined ? !nodeData.data.draggable : false;
+  var canOpen = nodeData.data.fixed !== undefined ? !nodeData.data.fixed : true;
 
   // handles whether it is a note or a riseabove
   if(nodeData._to.data === undefined){
@@ -84,6 +85,7 @@ function handleNote(server, token, id, nodeData, authorData, viewSettings, group
         kfId: nodeData.to,
         linkId: nodeData._id,
         type: type,
+        canOpen: canOpen,
       },
       locked: isPositionLocked,
       classes: [readStatus, viewSettings.nodeClass],
@@ -102,6 +104,7 @@ function handleAttachment(server, token, nodes, nodeData, authorData, viewSettin
   var groupName = nodeData._to.group ? groups.find(group => group._id === nodeData._to.group).title : null;
   var isPositionLocked = nodeData.data.draggable !== undefined ? !nodeData.data.draggable : false;
   var showInPlace = nodeData.data.showInPlace !== undefined ? nodeData.data.showInPlace : false;
+  var canOpen = nodeData.data.fixed !== undefined ? !nodeData.data.fixed : true;
 
   return getApiObjectsObjectId(token, server, nodeData.to).then(function(result){
 
@@ -144,7 +147,8 @@ function handleAttachment(server, token, nodes, nodeData, authorData, viewSettin
           kfId: nodeData.to,
           linkId: nodeData._id,
           type: nodeData._to.type,
-          download: server + result.data.url.substring(1,)
+          download: server + result.data.url.substring(1,),
+          canOpen: canOpen,
         },
         locked: isPositionLocked,
         classes: ["attachment", viewSettings.nodeClass],
@@ -166,6 +170,7 @@ function handleDrawing(server, token, nodes, nodeData, authorData, viewSettings,
   var groupName = nodeData._to.group ? groups.find(group => group._id === nodeData._to.group).title : null;
   var isPositionLocked = nodeData.data.draggable !== undefined ? !nodeData.data.draggable : false;
   var showInPlace = nodeData.data.showInPlace !== undefined ? nodeData.data.showInPlace : false;
+  var canOpen = nodeData.data.fixed !== undefined ? !nodeData.data.fixed : true;
 
   return getApiObjectsObjectId(token, server, nodeData.to).then(function(result){
     if(showInPlace){
@@ -213,7 +218,8 @@ function handleDrawing(server, token, nodes, nodeData, authorData, viewSettings,
           kfId: nodeData.to,
           linkId: nodeData._id,
           type: nodeData._to.type,
-          download: 'data:image/svg+xml;utf8,' + encodeURIComponent('<?xml version="1.0" encoding="UTF-8"?><!DOCTYPE svg>' + result.data.svg)
+          download: 'data:image/svg+xml;utf8,' + encodeURIComponent('<?xml version="1.0" encoding="UTF-8"?><!DOCTYPE svg>' + result.data.svg),
+          canOpen: canOpen,
         },
         locked: isPositionLocked,
         classes: ["attachment", viewSettings.nodeClass],
@@ -233,6 +239,7 @@ function handleView(nodes, nodeData, authorData){
   var id = createCytoscapeId(nodes, nodeData.to);
   var authorName = matchAuthorId(nodeData._to.authors[0], authorData);
   var isPositionLocked = nodeData.data.draggable !== undefined ? !nodeData.data.draggable : false;
+  var canOpen = nodeData.data.fixed !== undefined ? !nodeData.data.fixed : true;
 
   return {
     group: 'nodes',
@@ -244,6 +251,7 @@ function handleView(nodes, nodeData, authorData){
       linkId: nodeData._id,
       type: nodeData._to.type,
       communityId: nodeData.communityId,
+      canOpen: canOpen,
     },
     locked: isPositionLocked,
     classes: "view",

--- a/src/components/CommunityView/LightView/LightView.js
+++ b/src/components/CommunityView/LightView/LightView.js
@@ -113,6 +113,22 @@ class LightView extends Component {
                     filteredResults = notes.filter(note => noteIds.includes(note._id))
                     break;
 
+                case "time":
+                    var curr_date = new Date();
+                    filteredResults = notes.filter((note) => {
+                      const note_date = new Date(note.created);
+                      if(note_date !== "Invalid Date"){
+                        var diff = curr_date - note_date;
+                        var secondsDiff = diff/1000;
+
+                        if(query === "today" && secondsDiff <= 86400 ||
+                           query === "week" && secondsDiff <= 604800 ||
+                           query === "month" && secondsDiff <= 2592000 ||
+                           query === "year" && secondsDiff <= 31556952 ){ return note; }
+                      }
+                    });
+                    break;
+
                 default:
                     break;
             }

--- a/src/components/CommunityView/LightView/LightView.js
+++ b/src/components/CommunityView/LightView/LightView.js
@@ -121,11 +121,12 @@ class LightView extends Component {
                         var diff = curr_date - note_date;
                         var secondsDiff = diff/1000;
 
-                        if(query === "today" && secondsDiff <= 86400 ||
-                           query === "week" && secondsDiff <= 604800 ||
-                           query === "month" && secondsDiff <= 2592000 ||
-                           query === "year" && secondsDiff <= 31556952 ){ return note; }
+                        if((query === "today" && secondsDiff <= 86400) ||
+                           (query === "week" && secondsDiff <= 604800) ||
+                           (query === "month" && secondsDiff <= 2592000) ||
+                           (query === "year" && secondsDiff <= 31556952)){ return note; }
                       }
+                      return null;
                     });
                     break;
 

--- a/src/components/CommunityView/TopNavbar.js
+++ b/src/components/CommunityView/TopNavbar.js
@@ -21,11 +21,15 @@ class TopNavbar extends Component {
   handleFilter = (e) => {
       let value = e.target.value;
       var query;
+      // set defaults for scaffold, author, and time search
       if(value === "scaffold"){
+        // default scaffold is the first scaffold and its first support
         query = this.props.scaffolds[0].supports[0].to;
       } else if(value === "author"){
+        // default author is the current user
         query = this.props.user.firstName + " " + this.props.user.lastName;
       } else if(value === "time"){
+        // default time is today
         query = "today";
       } else {
         query = '';
@@ -39,7 +43,7 @@ class TopNavbar extends Component {
       const query = event.target.value
       this.setState({query: query});
       if(query === '' || this.props.filter === 'scaffold' || this.props.filter === "author" || this.props.filter === "time") this.props.setSearchQuery(query);
-  };
+  }
 
   handleSearchSubmit = (e) => {
     this.props.setSearchQuery(this.state.query);

--- a/src/components/CommunityView/View.js
+++ b/src/components/CommunityView/View.js
@@ -264,12 +264,13 @@ class View extends Component {
                               rootClose
                               overlay={
                                 <Popover id="layoutPopover">
-                                  <Popover.Title>Layout (Temporary)</Popover.Title>
+                                  <Popover.Title>Layouts (Temporary)</Popover.Title>
                                   <Popover.Content>
                                     <Row><Button value="preset" onClick={this.updateLayout} className={this.state.layout==="preset" ? 'activeLayout' : ''}>Original</Button></Row>
                                     <Row><Button value="grid" onClick={this.updateLayout} className={this.state.layout==="grid" ? 'activeLayout' : ''}>Grid</Button></Row>
                                     <Row><Button value="circle" onClick={this.updateLayout} className={this.state.layout==="circle" ? 'activeLayout' : ''}>Circle</Button></Row>
                                     <Row><Button value="spread" onClick={this.updateLayout} className={this.state.layout==="spread" ? 'activeLayout' : ''}>Spread</Button></Row>
+                                    <Row><Button value="cose" onClick={this.updateLayout} className={this.state.layout==="cose" ? 'activeLayout' : ''}>Cose</Button></Row>
                                   </Popover.Content>
                                 </Popover>
                               }>

--- a/src/components/CommunityView/View.js
+++ b/src/components/CommunityView/View.js
@@ -187,6 +187,7 @@ class View extends Component {
                              readLinks={this.props.readLinks}
                              onViewClick={this.onViewClick}
                              onNoteClick={(noteId)=>this.props.openContribution(noteId, "write")}
+                             updateParentLayoutProp={this.updateLayout}
                          />
                       :
                          <LightView/>;
@@ -265,9 +266,10 @@ class View extends Component {
                                 <Popover id="layoutPopover">
                                   <Popover.Title>Layout (Temporary)</Popover.Title>
                                   <Popover.Content>
-                                    <Row><Button value="preset" onClick={this.updateLayout} className={this.state.layout==="preset" ? 'activeLayout' : ''}>Preset</Button></Row>
+                                    <Row><Button value="preset" onClick={this.updateLayout} className={this.state.layout==="preset" ? 'activeLayout' : ''}>Original</Button></Row>
                                     <Row><Button value="grid" onClick={this.updateLayout} className={this.state.layout==="grid" ? 'activeLayout' : ''}>Grid</Button></Row>
                                     <Row><Button value="circle" onClick={this.updateLayout} className={this.state.layout==="circle" ? 'activeLayout' : ''}>Circle</Button></Row>
+                                    <Row><Button value="spread" onClick={this.updateLayout} className={this.state.layout==="spread" ? 'activeLayout' : ''}>Spread</Button></Row>
                                   </Popover.Content>
                                 </Popover>
                               }>

--- a/src/components/Login/Login.jsx
+++ b/src/components/Login/Login.jsx
@@ -123,8 +123,8 @@ class Login extends Component {
                     <Modal.Header>
                       <Modal.Title className="login-modal-title">
                           Knowledge Forum Demo
-                          <a className="kf-demo-modaltitle-btn" onClick={this.handleClose}><i className="fas fa-times"></i></a>
-                          <a className="kf-demo-modaltitle-btn" onClick={this.toggleFullScreenModal}><i className="fas fa-expand-alt"></i></a>
+                          <a href="/#" className="kf-demo-modaltitle-btn" onClick={this.handleClose}><i className="fas fa-times"></i></a>
+                          <a href="/#" className="kf-demo-modaltitle-btn" onClick={this.toggleFullScreenModal}><i className="fas fa-expand-alt"></i></a>
                       </Modal.Title>
                     </Modal.Header>
                     <Modal.Body className="login-modal-body" style={{padding: 0}}>

--- a/src/components/dialog/Dialog.js
+++ b/src/components/dialog/Dialog.js
@@ -26,7 +26,7 @@ const Dialog = props => {
             >
                 <Card className='dlg-card'>
                     <Card.Header className='dlg-card-header py-0' style={{alignItems: 'center', display: 'flex'}}>
-                        <span>{props.title}</span>
+                        <span>{!props.editable ? 'Note' : props.title}</span>
                         <Button onClick={props.onClose} variant='link' size='sm' style={{marginLeft:'auto'}}>x</Button>
                     </Card.Header>
                     <Card.Body className='dlg-card-body' style={{position: 'relative'}}>

--- a/src/config.js
+++ b/src/config.js
@@ -12,6 +12,7 @@ export const SERVERS = [
 ];
 
 // ZOOM VALUES FOR CYTOSCAPE GRAPH
+export const MIN_ZOOMED_FONT_SIZE = '6px';
 export const MINZOOM = 0.25;
 export const MAXZOOM = 10;
 


### PR DESCRIPTION
- Added support for "fixed", "locked", and "showInPlace" node attributes from kf6 
- Added support for opening support images  
- Added right click cytoscape extension "context-menus" 
  - Only support for opening nodes is implemented currently
- Added search by time functionality to the lightview component
  - Forgot to do this when it was added to the graphview component 
- Added node styling for when selected
- Added cytoscape "spread" and "cose" layouts as layout options 
- Added a new feature on box select event 
   - The graph removes all the unselected nodes and runs the cytoscape "spread" layout
   - This is an attempt to provide a better way to visually see tight clusters of many nodes 
   - It is still slow/laggy for the Guilderland community though, this may be fixable by tweaking the layout parameters
- Added a min-zoomed-font-size for cytoscape node labels that prevents labels from being rendered when they are too small to read anyway
  - This ONLY affects the node title, the author/date/group label is a separate entity provided from the node-html-label extension
 - Fixed a bug with the focusRecentAddition() function not highlighting new nodes properly 
 - Handled various console warning messages 